### PR TITLE
Change image URL to GitHub CDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <!-- markdownlint-disable MD041 -->
 
-![denopkg](./denopkg.png)
+![denopkg](https://raw.githubusercontent.com/denopkg/denopkg.com/master/denopkg.png)
 
 # [denopkg.com](https://denopkg.com)
 


### PR DESCRIPTION
After merging #5, image URL should be changed using GitHub CDN since the image does not load on https://denopkg.com because it uses the relative URL.

<details>
<summary><b>View page screenshot</b></summary><br/>

![denopkg.com](https://user-images.githubusercontent.com/8220954/82142167-a1fbb280-9864-11ea-8d08-82f3e24d9626.png)

</details>
