### PR TITLE
Use jsDelivr

### DIFF
--- a/src/pages/api/github.ts
+++ b/src/pages/api/github.ts
@@ -22,7 +22,7 @@ const handler: NextApiHandler = async (req, res) => {
   res.status(301)
   res.setHeader(
     'Location',
-    `https://raw.githubusercontent.com/${owner}/${repo}/${
+    `https://cdn.jsdelivr.net/gh/${owner}/${repo}@${
       versionSpecified ? '' : 'master'
     }${rest || '/mod.ts'}`
   )


### PR DESCRIPTION
Following up on the e-mail conversation, this PR changes redirects from raw GitHub to [jsDelivr CDN](https://www.jsdelivr.com/).