### PR TITLE
raw.github.com redirects to raw.githubusercontent.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ You wanna use a third-party library which is stored on GitHub in [Deno](https://
 Instead of writing:
 
 ```typescript
-import { opn } from 'https://raw.githubusercontent.com/hashrock/deno-opn/master/opn.ts'
+import { opn } from 'https://raw.github.com/hashrock/deno-opn/master/opn.ts'
 
 opn('https://example.com')
 ```


### PR DESCRIPTION
Hi,  
I don't know if you know but there is no need to type ``githubusercontent``, ``github`` works as well.  
I am not saying ``denopkg.com`` is not useful, I just think people should be aware of this fact.  

Best regards